### PR TITLE
Rewrite M4AGO core with type definition of marine aggregates

### DIFF
--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -283,13 +283,16 @@ contains
     ! molecular dynamic viscosity
     call dynvis(kpie, kpje, kpke, kbnd, pddpo, omask, ptho, psao, m4ago_ppo)
 
-    !$OMP PARALLEL DO PRIVATE(i,j,k,aggs)
+    !$OMP PARALLEL DO PRIVATE(i,j,k,aggs,agg_env)
     do j = 1,kpje
       do i = 1,kpie
         do k = 1,kpke
           if(pddpo(i,j,k) > dp_min .and. omask(i,j) > 0.5) then
+
+            ! Provide aggregates environment
             agg_env%rho_aq = rho_aq
             agg_env%mu     = dyn_vis(i,j,k)
+
             ! ------ prepare primary particle information to calculate aggregate properties
             call prepare_primary_particles(i, j, k,aggs,agg_env)
 

--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -427,7 +427,7 @@ contains
     V_dust  = n_dust*V_dp_dust*NUM_FAC
 
     ! calc frustule stickiness
-    stickiness_frustule = cell_det_mass/(cell_pot_det_mass +EPS_ONE)*stickiness_TEP           &
+    stickiness_frustule = cell_det_mass/(cell_pot_det_mass +EPS_ONE)*stickiness_TEP                &
                                & + (1. - cell_det_mass/(cell_pot_det_mass + EPS_ONE))              &
                                &   *stickiness_opal
 

--- a/src/mo_m4ago_core.f90
+++ b/src/mo_m4ago_core.f90
@@ -76,22 +76,22 @@ module mo_m4ago_core
   private
 
   type, public :: aggregates
-    integer :: NPrimPartTypes                       ! Number of primary particle types
-    real    :: av_dp                                ! mean primary particle diameter (m)
-    real    :: av_rho_p                             ! mean primary particle density (kg/m3)
-    real    :: df_agg                               ! aggregate fractal dimension - range: agg_df_min-agg_df_max (-)
-    real    :: b_agg                                ! aggregate number distribution slope (-)
-    real    :: dmax_agg                             ! maximum aggregate diameter (m)
-    real    :: stickiness_agg                       ! aggregate stickiness - range : 0-1 (-)
-    real    :: stickiness_frustule                  ! opal frustule stickiness
-    real    :: Re_crit_agg                          ! critical diameter-based particle Reynolds number for fragmentation
-    real    :: ws_aggregates                        ! mean aggregate sinking velocity (m/s)
-    real,dimension(:), allocatable :: dp_pp         ! primary particle diameter of each primary particle type (L)
-    real,dimension(:), allocatable :: rho_pp        ! primary particle density of each primary particle type (M/L^3)
-    real,dimension(:), allocatable :: stickiness_pp ! stickiness of each primary particle type (-)
-    real,dimension(:), allocatable :: n_pp          ! total number of each primary particle type (#/L^3)
-    real,dimension(:), allocatable :: A_pp          ! surface area of each primary particle type (L^2/L^3)
-    real,dimension(:), allocatable :: V_pp          ! total volume of each primary particle type (L^3/L^3)
+    integer  :: NPrimPartTypes                       ! Number of primary particle types
+    real(wp) :: av_dp                                ! mean primary particle diameter (m)
+    real(wp) :: av_rho_p                             ! mean primary particle density (kg/m3)
+    real(wp) :: df_agg                               ! aggregate fractal dimension - range: agg_df_min-agg_df_max (-)
+    real(wp) :: b_agg                                ! aggregate number distribution slope (-)
+    real(wp) :: dmax_agg                             ! maximum aggregate diameter (m)
+    real(wp) :: stickiness_agg                       ! aggregate stickiness - range : 0-1 (-)
+    real(wp) :: stickiness_frustule                  ! opal frustule stickiness
+    real(wp) :: Re_crit_agg                          ! critical diameter-based particle Reynolds number for fragmentation
+    real(wp) :: ws_aggregates                        ! mean aggregate sinking velocity (m/s)
+    real(wp),dimension(:), allocatable :: dp_pp         ! primary particle diameter of each primary particle type (L)
+    real(wp),dimension(:), allocatable :: rho_pp        ! primary particle density of each primary particle type (M/L^3)
+    real(wp),dimension(:), allocatable :: stickiness_pp ! stickiness of each primary particle type (-)
+    real(wp),dimension(:), allocatable :: n_pp          ! total number of each primary particle type (#/L^3)
+    real(wp),dimension(:), allocatable :: A_pp          ! surface area of each primary particle type (L^2/L^3)
+    real(wp),dimension(:), allocatable :: V_pp          ! total volume of each primary particle type (L^3/L^3)
   end type aggregates
 
   ! Public subroutines & functions
@@ -110,8 +110,8 @@ module mo_m4ago_core
   real(wp), protected :: agg_df_min,agg_df_max             ! minimum and maximum fractal dim of aggregates
   real(wp), protected :: df_slope                          ! slope of df versus stickiness mapping
   real(wp), protected :: stickiness_min,stickiness_max     ! minimum and maximum stickiness of marine aggregates
-  real(wp), parameter :: rho_aq         = 1025.            ! water reference density  (1025 kg/m^3)
-  real(wp), parameter :: grav_acc_const = 9.81             ! gravitational acceleration constant
+  real(wp), parameter :: rho_aq         = 1025._wp         ! water reference density  (1025 kg/m^3)
+  real(wp), parameter :: grav_acc_const = 9.81_wp          ! gravitational acceleration constant
 
   ! constants for the drag coefficient CD according to Ji & Logan 1991
   real(wp), parameter :: AJ1 = 24.00_wp
@@ -173,13 +173,13 @@ contains
     real(wp)    :: V_solid
     real(wp)    :: Vdpfrac
 
-    aggs%av_dp          = 0.
-    aggs%av_rho_p       = 0.
-    aggs%stickiness_agg = 0.
+    aggs%av_dp          = 0._wp
+    aggs%av_rho_p       = 0._wp
+    aggs%stickiness_agg = 0._wp
 
-    A_total        = 0.
-    V_solid        = 0.
-    Vdpfrac        = 0.
+    A_total        = 0._wp
+    V_solid        = 0._wp
+    Vdpfrac        = 0._wp
 
     ! ------ calc mean aggregate stickiness
     do ipp = 1,aggs%NPrimPartTypes

--- a/src/mo_m4ago_core.f90
+++ b/src/mo_m4ago_core.f90
@@ -413,7 +413,7 @@ contains
     real        :: nu_vis
 
     nu_vis  =  mu/rho_aq
-    max_agg_diam_white = (aggs%Re_crit_agg*nu_vis)**((2. - BJ3)/aggs%df_agg)                            &
+    max_agg_diam_white = (aggs%Re_crit_agg*nu_vis)**((2. - BJ3)/aggs%df_agg)                       &
                         & /((4./3.)*(aggs%av_rho_p - rho_aq)/rho_aq                                &
                         & *aggs%av_dp**(3. - aggs%df_agg)*grav_acc_const                           &
                         & /(AJ3*nu_vis**BJ3))**(1./aggs%df_agg)
@@ -434,7 +434,7 @@ contains
                             & *(4.-aggs%b_agg)*(aggs%dmax_agg**(1.+aggs%df_agg-aggs%b_agg)         &
                             &                  - aggs%av_dp**(1.+aggs%df_agg-aggs%b_agg))          &
                             &  / ((1.+aggs%df_agg-aggs%b_agg)                                      &
-                            & *(aggs%dmax_agg**(4.-aggs%b_agg) - aggs%av_dp**(4.-aggs%b_agg)))      &
+                            & *(aggs%dmax_agg**(4.-aggs%b_agg) - aggs%av_dp**(4.-aggs%b_agg)))     &
                             & + rho_aq
 
   end function volweighted_agg_density


### PR DESCRIPTION
With this PR, two types are introduced to M4AGO core, holding i) marine aggregate-related variables and ii) the local environment of the aggregates. The branch has been tested in NorESM2.1.3 with BLOM tag v1.6.2 and results in bfb compared to the former tag version dev-1.0.2.  