### PR TITLE
Introduce explicit working precision -kind- statements

### DIFF
--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -290,7 +290,6 @@ contains
     ! molecular dynamic viscosity
     call dynvis(kpie, kpje, kpke, kbnd, pddpo, omask, ptho, psao, m4ago_ppo)
 
-    !commented: $OMP PARALLEL DO PRIVATE(i,j,k) COPYIN(av_dp,av_rho_p,df_agg,b_agg,Lmax_agg,rho_aq,stickiness_agg,ws_aggregates,dp_primpart,rho_primpart,n_primpart,A_primpart,V_primpart,stickiness_primpart)
     !$OMP PARALLEL DO PRIVATE(i,j,k)
     do j = 1,kpje
       do i = 1,kpie

--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -143,8 +143,7 @@ module mo_ihamocc4m4ago
   real(wp), protected :: rho_frustule                             ! density of diatom frustule incl. opal, detritus and water
   real(wp), protected :: rho_diatom                               ! density of either hollow frustule
   real(wp), protected :: stickiness_frustule                      ! stickiness of the diatom frustile as primary particle
-  !$OMP THREADPRIVATE(free_detritus,rho_diatom,cell_det_mass,cell_pot_det_mass,V_POM_cell,V_aq,rho_frustule)
-  
+
   ! Parameters and fields for M4AGO core
   integer, parameter :: NPrimPartTypes = 4 ! Number of primary particle types generated from the biogeochemistry model
   real(wp), protected, dimension(NPrimPartTypes)  :: dp_primpart  ! primary particle diameter of each primary particle type (L)
@@ -153,7 +152,6 @@ module mo_ihamocc4m4ago
   real(wp), protected, dimension(NPrimPartTypes)  :: V_primpart   ! total volume of each primary particle type (L^3/L^3)
   real(wp), protected, dimension(NPrimPartTypes)  :: A_primpart   ! Surface area of each primary particle type (L^2/L^3)
   real(wp), protected, dimension(NPrimPartTypes)  :: stickiness_primpart ! Stickiness of each primary particle type (-)
-  !$OMP THREADPRIVATE(dp_primpart,rho_primpart,n_primpart,A_primpart,V_primpart,stickiness_primpart)
 
   real(wp),allocatable :: ws_agg(:,:,:)       ! mass concentration-weighted aggregate mean sinking velocity
   real(wp),allocatable :: dyn_vis(:,:,:)      ! molecular dynamic viscosity

--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -77,6 +77,7 @@ module mo_ihamocc4m4ago
   use mo_param1_bgc,    only: iopal, ifdust, icalc, idet
 
   ! M4AGO routines:
+  use mo_m4ago_kind,    only: wp
   use mo_m4ago_core,    only: av_dp, av_rho_p, df_agg, b_agg, Lmax_agg,                            &
                             & stickiness_agg,rho_aq,ONE_SIXTH,PI,                                  &
                             & ws_aggregates,ws_Re_approx,volweighted_agg_density,                  &
@@ -104,60 +105,60 @@ module mo_ihamocc4m4ago
   ! biogeochemistry model-specific parameters
   ! ------------------------------------------------------------------------------------------------
   ! primary particle diameter for POM & PIM species involved in parametrized aggregation (m)
-  real, protected :: dp_dust ! primary particle diameter dust
-  real, protected :: dp_det  ! primary particle diameter detritus
-  real, protected :: dp_calc ! primary particle diameter calc
-  real, protected :: dp_opal ! primary particle diameter opal
+  real(wp), protected :: dp_dust ! primary particle diameter dust
+  real(wp), protected :: dp_det  ! primary particle diameter detritus
+  real(wp), protected :: dp_calc ! primary particle diameter calc
+  real(wp), protected :: dp_opal ! primary particle diameter opal
 
   ! Stickiness of primary particles
-  real, protected :: stickiness_TEP  ! stickiness of TEP (related to opal frustules)
-  real, protected :: stickiness_det  ! normal detritus stickiness
-  real, protected :: stickiness_opal ! stickiness of opal (without TEP - just normal coating)
-  real, protected :: stickiness_calc ! stickiness of calc particles (coated with organics)
-  real, protected :: stickiness_dust ! stickiness of dust particles (coated with organics)
+  real(wp), protected :: stickiness_TEP  ! stickiness of TEP (related to opal frustules)
+  real(wp), protected :: stickiness_det  ! normal detritus stickiness
+  real(wp), protected :: stickiness_opal ! stickiness of opal (without TEP - just normal coating)
+  real(wp), protected :: stickiness_calc ! stickiness of calc particles (coated with organics)
+  real(wp), protected :: stickiness_dust ! stickiness of dust particles (coated with organics)
 
-  real, protected :: agg_df_max      ! maximum fractal dimension of aggregates (~2.5)
-  real, protected :: agg_df_min      ! minimum fractal dimension of aggregates (~1.2 - 1.6)
-  real, protected :: rho_TEP         ! density of TEP particles
-  real, protected :: agg_org_dens    ! organic detritus density (alternative to orgdens to avoid negative ws)
-  real, protected :: agg_Re_crit     ! critical particle Reynolds number for fragmentation
+  real(wp), protected :: agg_df_max      ! maximum fractal dimension of aggregates (~2.5)
+  real(wp), protected :: agg_df_min      ! minimum fractal dimension of aggregates (~1.2 - 1.6)
+  real(wp), protected :: rho_TEP         ! density of TEP particles
+  real(wp), protected :: agg_org_dens    ! organic detritus density (alternative to orgdens to avoid negative ws)
+  real(wp), protected :: agg_Re_crit     ! critical particle Reynolds number for fragmentation
 
   ! calculated model-specific parameters
-  real, protected :: det_mol2mass ! mol detritus P/m^3 to kg POM /m^3 (according to stoichiometry)
-  real, protected :: V_dp_dust,V_dp_det,V_dp_calc,V_dp_opal   ! volumes of primary particles (L^3)
-  real, protected :: A_dp_dust,A_dp_det,A_dp_calc,A_dp_opal   ! surface areas of primary particles (L^2)
-  real, protected :: stickiness_min, stickiness_max           ! minimum and maximum stickiness of primary particles
-  real, protected :: rho_V_dp_dust,rho_V_dp_det,rho_V_dp_calc ! rho_V_dp_opal ! mass of primary particles (M)
-  real, protected :: Rm_SiP                                   ! molar mass ratio opal (SiO_2) to POM
-  real, protected :: thick_shell                              ! diatom frustule shell thickness (L)
-  real, protected :: d_frustule_inner                         ! diameter of hollow part in diatom frustule (L)
-  real, protected :: V_frustule_inner                         ! volume of hollow part in diatom frustule (L^3)
-  real, protected :: V_frustule_opal                          ! volume of opal shell material (L^3)
-  real, protected :: rho_V_frustule_opal                      ! mass of frustule material (M)
-  real, protected :: cell_det_mass                            ! mass of detritus material in diatoms
-  real, protected :: cell_pot_det_mass                        ! potential (max) mass detritus material in diatoms
-  real, protected :: free_detritus                            ! freely available detritus mass outside the frustule
-  real, protected :: V_POM_cell                               ! volume of POM in frustule
-  real, protected :: V_aq                                     ! volume of water space in frustule
-  real, protected :: rho_frustule                             ! density of diatom frustule incl. opal, detritus and water
-  real, protected :: rho_diatom                               ! density of either hollow frustule
-  real, protected :: stickiness_frustule                      ! stickiness of the diatom frustile as primary particle
+  real(wp), protected :: det_mol2mass ! mol detritus P/m^3 to kg POM /m^3 (according to stoichiometry)
+  real(wp), protected :: V_dp_dust,V_dp_det,V_dp_calc,V_dp_opal   ! volumes of primary particles (L^3)
+  real(wp), protected :: A_dp_dust,A_dp_det,A_dp_calc,A_dp_opal   ! surface areas of primary particles (L^2)
+  real(wp), protected :: stickiness_min, stickiness_max           ! minimum and maximum stickiness of primary particles
+  real(wp), protected :: rho_V_dp_dust,rho_V_dp_det,rho_V_dp_calc ! rho_V_dp_opal ! mass of primary particles (M)
+  real(wp), protected :: Rm_SiP                                   ! molar mass ratio opal (SiO_2) to POM
+  real(wp), protected :: thick_shell                              ! diatom frustule shell thickness (L)
+  real(wp), protected :: d_frustule_inner                         ! diameter of hollow part in diatom frustule (L)
+  real(wp), protected :: V_frustule_inner                         ! volume of hollow part in diatom frustule (L^3)
+  real(wp), protected :: V_frustule_opal                          ! volume of opal shell material (L^3)
+  real(wp), protected :: rho_V_frustule_opal                      ! mass of frustule material (M)
+  real(wp), protected :: cell_det_mass                            ! mass of detritus material in diatoms
+  real(wp), protected :: cell_pot_det_mass                        ! potential (max) mass detritus material in diatoms
+  real(wp), protected :: free_detritus                            ! freely available detritus mass outside the frustule
+  real(wp), protected :: V_POM_cell                               ! volume of POM in frustule
+  real(wp), protected :: V_aq                                     ! volume of water space in frustule
+  real(wp), protected :: rho_frustule                             ! density of diatom frustule incl. opal, detritus and water
+  real(wp), protected :: rho_diatom                               ! density of either hollow frustule
+  real(wp), protected :: stickiness_frustule                      ! stickiness of the diatom frustile as primary particle
 
   ! Parameters and fields for M4AGO core
   integer, parameter :: NPrimPartTypes = 4 ! Number of primary particle types generated from the biogeochemistry model
-  real,    protected, dimension(NPrimPartTypes)  :: dp_primpart  ! primary particle diameter of each primary particle type (L)
-  real,    protected, dimension(NPrimPartTypes)  :: rho_primpart ! primary particle density of each primary particle type (M/L^3)
-  real,    protected, dimension(NPrimPartTypes)  :: n_primpart   ! total number of each primary particle type (#/L^3)
-  real,    protected, dimension(NPrimPartTypes)  :: V_primpart   ! total volume of each primary particle type (L^3/L^3)
-  real,    protected, dimension(NPrimPartTypes)  :: A_primpart   ! Surface area of each primary particle type (L^2/L^3)
-  real,    protected, dimension(NPrimPartTypes)  :: stickiness_primpart ! Stickiness of each primary particle type (-)
+  real(wp), protected, dimension(NPrimPartTypes)  :: dp_primpart  ! primary particle diameter of each primary particle type (L)
+  real(wp), protected, dimension(NPrimPartTypes)  :: rho_primpart ! primary particle density of each primary particle type (M/L^3)
+  real(wp), protected, dimension(NPrimPartTypes)  :: n_primpart   ! total number of each primary particle type (#/L^3)
+  real(wp), protected, dimension(NPrimPartTypes)  :: V_primpart   ! total volume of each primary particle type (L^3/L^3)
+  real(wp), protected, dimension(NPrimPartTypes)  :: A_primpart   ! Surface area of each primary particle type (L^2/L^3)
+  real(wp), protected, dimension(NPrimPartTypes)  :: stickiness_primpart ! Stickiness of each primary particle type (-)
 
-  real,allocatable :: ws_agg(:,:,:)       ! mass concentration-weighted aggregate mean sinking velocity
-  real,allocatable :: dyn_vis(:,:,:)      ! molecular dynamic viscosity
-  real,allocatable :: m4ago_ppo(:,:,:)    ! pressure
+  real(wp),allocatable :: ws_agg(:,:,:)       ! mass concentration-weighted aggregate mean sinking velocity
+  real(wp),allocatable :: dyn_vis(:,:,:)      ! molecular dynamic viscosity
+  real(wp),allocatable :: m4ago_ppo(:,:,:)    ! pressure
 
   ! Marine aggregate diagnostics
-  real, dimension (:,:,:,:), allocatable, target :: aggregate_diagnostics    ! diagnostics for marine aggregates
+  real(wp), dimension (:,:,:,:), allocatable, target :: aggregate_diagnostics    ! diagnostics for marine aggregates
 
   integer, parameter :: kav_dp               =  1, &
                         kav_rho_p            =  2, &
@@ -174,8 +175,8 @@ module mo_ihamocc4m4ago
                         naggdiag             = 12
 
   ! Internally used parameters and values
-  real, parameter :: NUM_FAC = 1.e9             ! factor to avoid numerical precision problems
-  real, parameter :: EPS_ONE = EPSILON(1.)
+  real(wp), parameter :: NUM_FAC = 1.e9_wp             ! factor to avoid numerical precision problems
+  real(wp), parameter :: EPS_ONE = EPSILON(1._wp)
 
 contains
 
@@ -188,28 +189,28 @@ contains
     implicit none
 
     ! Primary particle sizes
-    dp_dust = 2.e-6      ! following the classical HAMOCC parametrization
-    dp_det  = 4.e-6      ! not well defined
-    dp_calc = 3.e-6      ! following Henderiks 2008, Henderiks & Pagani 2008
-    dp_opal = 20.e-6     ! mean frustule diameter of diatoms
+    dp_dust = 2.e-6_wp      ! following the classical HAMOCC parametrization
+    dp_det  = 4.e-6_wp      ! not well defined
+    dp_calc = 3.e-6_wp      ! following Henderiks 2008, Henderiks & Pagani 2008
+    dp_opal = 20.e-6_wp     ! mean frustule diameter of diatoms
 
     ! Stickiness values
-    stickiness_TEP    = 0.19
-    stickiness_det    = 0.1
-    stickiness_opal   = 0.08
-    stickiness_calc   = 0.09
-    stickiness_dust   = 0.07
+    stickiness_TEP    = 0.19_wp
+    stickiness_det    = 0.1_wp
+    stickiness_opal   = 0.08_wp
+    stickiness_calc   = 0.09_wp
+    stickiness_dust   = 0.07_wp
 
     ! Minimum and maximum aggregate fractal dimension
-    agg_df_min        = 1.6
-    agg_df_max        = 2.4
+    agg_df_min        = 1.6_wp
+    agg_df_max        = 2.4_wp
 
     ! Density of primary particles
-    rho_TEP           = 800. ! 700.-840. kg/m^3 Azetsu-Scott & Passow 2004
-    agg_org_dens      = 1100. ! detritus density - don't use orgdens to avoid negative ws
+    rho_TEP           = 800._wp ! 700.-840. kg/m^3 Azetsu-Scott & Passow 2004
+    agg_org_dens      = 1100._wp ! detritus density - don't use orgdens to avoid negative ws
 
     ! Critical particle Reynolds number for limiting nr-distribution
-    agg_Re_crit       = 20.
+    agg_Re_crit       = 20._wp
 
   end subroutine init_m4ago_nml_params
 
@@ -220,19 +221,19 @@ contains
     !!
 
     implicit none
-    det_mol2mass   = 3166.  ! mol detritus P/m^3 to kg POM /m^3 (according to stoichiometry)
+    det_mol2mass   = 3166._wp  ! mol detritus P/m^3 to kg POM /m^3 (according to stoichiometry)
 
     ! Volume of an individual primary particle*NUMFAC
-    V_dp_dust = ONE_SIXTH*PI*dp_dust**3.*NUM_FAC
-    V_dp_det  = ONE_SIXTH*PI*dp_det**3. *NUM_FAC
-    V_dp_calc = ONE_SIXTH*PI*dp_calc**3.*NUM_FAC
-    V_dp_opal = ONE_SIXTH*PI*dp_opal**3.*NUM_FAC
+    V_dp_dust = ONE_SIXTH*PI*dp_dust**3*NUM_FAC
+    V_dp_det  = ONE_SIXTH*PI*dp_det**3 *NUM_FAC
+    V_dp_calc = ONE_SIXTH*PI*dp_calc**3*NUM_FAC
+    V_dp_opal = ONE_SIXTH*PI*dp_opal**3*NUM_FAC
 
     ! Surface area of an individual primary particle*NUMFAC
-    A_dp_dust = PI*dp_dust**2.*NUM_FAC
-    A_dp_det  = PI*dp_det**2. *NUM_FAC
-    A_dp_calc = PI*dp_calc**2.*NUM_FAC
-    A_dp_opal = PI*dp_opal**2.*NUM_FAC
+    A_dp_dust = PI*dp_dust**2*NUM_FAC
+    A_dp_det  = PI*dp_det**2 *NUM_FAC
+    A_dp_calc = PI*dp_calc**2*NUM_FAC
+    A_dp_opal = PI*dp_opal**2*NUM_FAC
 
     ! Mass of an individual primary particle*NUMFAC
     rho_V_dp_dust = V_dp_dust*claydens
@@ -241,12 +242,12 @@ contains
 
     Rm_SiP              = ropal*opalwei/det_mol2mass
     ! shell thickness
-    thick_shell         = 0.5*dp_opal*(1. - (opaldens/(Rm_SiP*agg_org_dens+opaldens))**(1./3.))
-    d_frustule_inner    = dp_opal - 2.*thick_shell
+    thick_shell         = 0.5_wp*dp_opal*(1._wp - (opaldens/(Rm_SiP*agg_org_dens+opaldens))**(1._wp/3._wp))
+    d_frustule_inner    = dp_opal - 2._wp*thick_shell
     ! volume of hollow part of frustule
-    V_frustule_inner    = ONE_SIXTH* PI*d_frustule_inner**3.*NUM_FAC
+    V_frustule_inner    = ONE_SIXTH* PI*d_frustule_inner**3*NUM_FAC
     ! volume of opal part of frustule
-    V_frustule_opal     = ONE_SIXTH*PI*(dp_opal**3. - d_frustule_inner**3.)*NUM_FAC
+    V_frustule_opal     = ONE_SIXTH*PI*(dp_opal**3 - d_frustule_inner**3)*NUM_FAC
     rho_V_frustule_opal = V_frustule_opal*opaldens
 
     ! Minimum and maximum reachable stickiness
@@ -303,7 +304,7 @@ contains
             call ws_Re_approx(dyn_vis(i,j,k))
 
             ! Limit settling velocity wrt CFL:
-            ws_agg(i,j,k) = min(ws_aggregates*dtbgc, 0.99*pddpo(i,j,k)) ! (m/s -> m/d)*dtb
+            ws_agg(i,j,k) = min(ws_aggregates*dtbgc, 0.99_wp*pddpo(i,j,k)) ! (m/s -> m/d)*dtb
 
 
             ! ============================== Write general diagnostics ============
@@ -345,29 +346,29 @@ contains
     integer, intent(in)  :: j                  !< 2nd real of model grid.
     integer, intent(in)  :: k                  !< 3rd (vertical) real of model grid.
 
-    real :: C_det,C_opal,C_calc,C_dust         ! Concentration of tracers
-    real :: n_det,n_opal,n_calc,n_dust         ! total primary particle number (#)
-    real :: A_dust,A_det,A_calc,A_opal,A_total ! total surface area of primary particles per unit volume (L^2/L^3)
-    real :: V_det,V_opal,V_calc,V_dust,V_solid ! total volume of primary particles in a unit volume (L^3/L^3)
+    real(wp) :: C_det,C_opal,C_calc,C_dust         ! Concentration of tracers
+    real(wp) :: n_det,n_opal,n_calc,n_dust         ! total primary particle number (#)
+    real(wp) :: A_dust,A_det,A_calc,A_opal,A_total ! total surface area of primary particles per unit volume (L^2/L^3)
+    real(wp) :: V_det,V_opal,V_calc,V_dust,V_solid ! total volume of primary particles in a unit volume (L^3/L^3)
 
     C_det  = abs(ocetra(i,j,k,idet))
     C_opal = abs(ocetra(i,j,k,iopal))
     C_calc = abs(ocetra(i,j,k,icalc))
     C_dust = abs(ocetra(i,j,k,ifdust))
 
-    n_det   = 0. ! number of primary particles in a unit volume
-    n_opal  = 0.
-    n_dust  = 0.
-    n_calc  = 0.
+    n_det   = 0._wp ! number of primary particles in a unit volume
+    n_opal  = 0._wp
+    n_dust  = 0._wp
+    n_calc  = 0._wp
 
-    V_det   = 0. ! total volume of primary particles in a unit volume
-    V_opal  = 0.
-    V_calc  = 0.
-    V_dust  = 0.
-    V_solid = 0.
+    V_det   = 0._wp ! total volume of primary particles in a unit volume
+    V_opal  = 0._wp
+    V_calc  = 0._wp
+    V_dust  = 0._wp
+    V_solid = 0._wp
 
-    free_detritus = 0.
-    rho_diatom    = 0.
+    free_detritus = 0._wp
+    rho_diatom    = 0._wp
     ! n_det are detritus primary particle that are
     ! NOT linked to any diatom frustule
     ! n_opal are number of frustule-like primary particles possessing
@@ -378,11 +379,11 @@ contains
     ! describing diatom frustule as hollow sphere
     ! that is completely or partially filled with detritus
     ! and water
-    cell_det_mass     = 0.
-    cell_pot_det_mass = 0.
-    V_POM_cell        = 0.
-    V_aq              = 0.
-    rho_frustule      = 0.
+    cell_det_mass     = 0._wp
+    cell_pot_det_mass = 0._wp
+    V_POM_cell        = 0._wp
+    V_aq              = 0._wp
+    rho_frustule      = 0._wp
 
     ! number of opal frustules (/NUM_FAC)
     n_opal = C_opal*opalwei/rho_V_frustule_opal
@@ -391,6 +392,8 @@ contains
 
     ! detritus mass inside frustules
     cell_det_mass = min(cell_pot_det_mass, C_det*det_mol2mass - EPS_ONE)
+    ! better: cell_det_mass = max(0._wp,min(cell_pot_det_mass,C_det*det_mol2mass))
+
 
     ! volume of detritus component in cell
     V_POM_cell = (cell_det_mass/n_opal)/agg_org_dens
@@ -404,7 +407,7 @@ contains
     ! mass of extra cellular detritus particles
     free_detritus = C_det*det_mol2mass  - cell_det_mass
     rho_diatom = (rho_frustule + cell_det_mass/cell_pot_det_mass*rho_TEP)                          &
-                   /(1. + cell_det_mass/cell_pot_det_mass)
+                   /(1._wp + cell_det_mass/cell_pot_det_mass)
 
     ! number of primary particles
     n_det  = free_detritus/rho_V_dp_det  ! includes NUM_FAC
@@ -425,7 +428,7 @@ contains
 
     ! calc frustule stickiness
     stickiness_frustule = cell_det_mass/(cell_pot_det_mass +EPS_ONE)*stickiness_TEP                &
-                               & + (1. - cell_det_mass/(cell_pot_det_mass + EPS_ONE))              &
+                               & + (1._wp - cell_det_mass/(cell_pot_det_mass + EPS_ONE))           &
                                &   *stickiness_opal
 
 
@@ -468,10 +471,10 @@ contains
     allocate(m4ago_ppo(kpie,kpje,kpke))
 
     ! Initialization
-    aggregate_diagnostics = 0.
-    m4ago_ppo             = 0.
-    ws_agg                = 0.
-    dyn_vis               = 0.
+    aggregate_diagnostics = 0._wp
+    m4ago_ppo             = 0._wp
+    ws_agg                = 0._wp
+    dyn_vis               = 0._wp
 
   end subroutine alloc_mem_m4ago
 
@@ -505,8 +508,8 @@ contains
     do k = 1,kpke
       do j = 1,kpje
         do i = 1,kpie
-          if(omask(i,j) > 0.5 .and. pddpo(i,j,k) .gt. dp_min) then
-            m4ago_ppo(i,j,k) = 1e5 * ptiestu(i,j,k)*98060.*1.027e-6 ! pressure in unit Pa, 98060 = onem
+          if(omask(i,j) > 0.5_wp .and. pddpo(i,j,k) .gt. dp_min) then
+            m4ago_ppo(i,j,k) = 1e5_wp * ptiestu(i,j,k)*98060._wp*1.027e-6_wp ! pressure in unit Pa, 98060 = onem
           endif
         enddo
       enddo
@@ -539,22 +542,22 @@ contains
     real, intent(in) :: ppo(kpie,kpje,kpke)  !< pressure [Pa].
 
     ! Local variables
-    real    :: press_val  ! Pascal/rho -> dbar
-    real    :: ptho_val,psao_val
+    real(wp)    :: press_val  ! Pascal/rho -> dbar
+    real(wp)    :: ptho_val,psao_val
     integer :: i,j,k,kch
     kch = 0
     !$OMP PARALLEL DO PRIVATE(i,j,k,press_val,ptho_val,psao_val,kch)
     do j = 1,kpje
       do i = 1,kpie
         do k = 1,kpke
-          if(pddpo(i,j,k) > dp_min .and. omask(i,j) > 0.5) then
+          if(pddpo(i,j,k) > dp_min .and. omask(i,j) > 0.5_wp) then
             kch = merge(k+1,k,k<kpke)
-            if(pddpo(i,j,kch) > 0.5) then
-              press_val    = 0.5*(ppo(i,j,k)  + ppo(i,j,kch))*1.e-5 ! Pascal -> dbar
-              ptho_val     = 0.5*(ptho(i,j,k) + ptho(i,j,kch))
-              psao_val     = 0.5*(psao(i,j,k) + ptho(i,j,kch))
+            if(pddpo(i,j,kch) > 0.5_wp) then
+              press_val    = 0.5_wp*(ppo(i,j,k)  + ppo(i,j,kch))*1.e-5_wp ! Pascal -> dbar
+              ptho_val     = 0.5_wp*(ptho(i,j,k) + ptho(i,j,kch))
+              psao_val     = 0.5_wp*(psao(i,j,k) + ptho(i,j,kch))
             else
-              press_val    = ppo(i,j,k)*1.e-5 ! Pascal -> dbar
+              press_val    = ppo(i,j,k)*1.e-5_wp ! Pascal -> dbar
               ptho_val     = ptho(i,j,k)
               psao_val     = psao(i,j,k)
             endif

--- a/src/mo_ihamocc4m4ago.f90
+++ b/src/mo_ihamocc4m4ago.f90
@@ -142,6 +142,7 @@ module mo_ihamocc4m4ago
   real, protected :: rho_frustule                             ! density of diatom frustule incl. opal, detritus and water
   real, protected :: rho_diatom                               ! density of either hollow frustule
   real, protected :: stickiness_frustule                      ! stickiness of the diatom frustile as primary particle
+  !$OMP THREADPRIVATE(free_detritus,rho_diatom,cell_det_mass,cell_pot_det_mass,V_POM_cell,V_aq,rho_frustule)
 
   ! Parameters and fields for M4AGO core
   integer, parameter :: NPrimPartTypes = 4 ! Number of primary particle types generated from the biogeochemistry model
@@ -151,6 +152,8 @@ module mo_ihamocc4m4ago
   real,    protected, dimension(NPrimPartTypes)  :: V_primpart   ! total volume of each primary particle type (L^3/L^3)
   real,    protected, dimension(NPrimPartTypes)  :: A_primpart   ! Surface area of each primary particle type (L^2/L^3)
   real,    protected, dimension(NPrimPartTypes)  :: stickiness_primpart ! Stickiness of each primary particle type (-)
+  !$OMP THREADPRIVATE(dp_primpart,rho_primpart,n_primpart,A_primpart,V_primpart,stickiness_primpart)
+
 
   real,allocatable :: ws_agg(:,:,:)       ! mass concentration-weighted aggregate mean sinking velocity
   real,allocatable :: dyn_vis(:,:,:)      ! molecular dynamic viscosity
@@ -287,6 +290,7 @@ contains
     ! molecular dynamic viscosity
     call dynvis(kpie, kpje, kpke, kbnd, pddpo, omask, ptho, psao, m4ago_ppo)
 
+    !commented: $OMP PARALLEL DO PRIVATE(i,j,k) COPYIN(av_dp,av_rho_p,df_agg,b_agg,Lmax_agg,rho_aq,stickiness_agg,ws_aggregates,dp_primpart,rho_primpart,n_primpart,A_primpart,V_primpart,stickiness_primpart)
     !$OMP PARALLEL DO PRIVATE(i,j,k)
     do j = 1,kpje
       do i = 1,kpie

--- a/src/mo_m4ago_core.f90
+++ b/src/mo_m4ago_core.f90
@@ -69,6 +69,8 @@
 
 module mo_m4ago_core
 
+  use mo_m4ago_kind, only: wp
+
   implicit none
 
   private
@@ -84,35 +86,35 @@ module mo_m4ago_core
   ! Public values
   public :: av_dp,av_rho_p,df_agg,b_agg,Lmax_agg,rho_aq,stickiness_agg,ONE_SIXTH,PI,ws_aggregates
 
-  real, protected :: av_dp                             ! mean primary particle diameter
-  real, protected :: av_rho_p                          ! mean primary particle density
-  real, protected :: df_agg                            ! fractal dimesnion of aggregates
-  real, protected :: b_agg                             ! aggregate number distribution slope
-  real, protected :: Lmax_agg                          ! maximum diamater of aggregates
-  real, protected :: agg_Re_crit                       ! critical diameter-based particle Reynolds number for fragmentation
-  real, protected :: agg_df_min,agg_df_max             ! minimum and maximum fractal dim of aggregates
-  real, protected :: df_slope                          ! slope of df versus stickiness mapping
-  real, protected :: stickiness_min,stickiness_max     ! minimum and maximum stickiness of marine aggregates
-  real, protected :: stickiness_agg                    ! mean aggregate stickiness
-  real, protected :: ws_aggregates                     ! mean mass concentration-weighted sinking velocity of aggregates
+  real(wp), protected :: av_dp                             ! mean primary particle diameter
+  real(wp), protected :: av_rho_p                          ! mean primary particle density
+  real(wp), protected :: df_agg                            ! fractal dimesnion of aggregates
+  real(wp), protected :: b_agg                             ! aggregate number distribution slope
+  real(wp), protected :: Lmax_agg                          ! maximum diamater of aggregates
+  real(wp), protected :: agg_Re_crit                       ! critical diameter-based particle Reynolds number for fragmentation
+  real(wp), protected :: agg_df_min,agg_df_max             ! minimum and maximum fractal dim of aggregates
+  real(wp), protected :: df_slope                          ! slope of df versus stickiness mapping
+  real(wp), protected :: stickiness_min,stickiness_max     ! minimum and maximum stickiness of marine aggregates
+  real(wp), protected :: stickiness_agg                    ! mean aggregate stickiness
+  real(wp), protected :: ws_aggregates                     ! mean mass concentration-weighted sinking velocity of aggregates
 
 
-  real, parameter :: rho_aq         = 1025.            ! water reference density  (1025 kg/m^3)
-  real, parameter :: grav_acc_const = 9.81             ! gravitational acceleration constant
+  real(wp), parameter :: rho_aq         = 1025._wp            ! water reference density  (1025 kg/m^3)
+  real(wp), parameter :: grav_acc_const = 9.81_wp             ! gravitational acceleration constant
 
   ! constants for the drag coefficient CD according to Ji & Logan 1991
-  real, parameter :: AJ1 = 24.00
-  real, parameter :: AJ2 = 29.03
-  real, parameter :: AJ3 = 14.15
-  real, parameter :: BJ1 = 1.0
-  real, parameter :: BJ2 = 0.871
-  real, parameter :: BJ3 = 0.547
+  real(wp), parameter :: AJ1 = 24.00_wp
+  real(wp), parameter :: AJ2 = 29.03_wp
+  real(wp), parameter :: AJ3 = 14.15_wp
+  real(wp), parameter :: BJ1 = 1.0_wp
+  real(wp), parameter :: BJ2 = 0.871_wp
+  real(wp), parameter :: BJ3 = 0.547_wp
 
 
   ! Helping parameters
-  real, parameter :: EPS_ONE   = EPSILON(1.)
-  real, parameter :: ONE_SIXTH = 1./6.
-  real, parameter :: PI        = 3.141592654
+  real(wp), parameter :: EPS_ONE   = EPSILON(1._wp)
+  real(wp), parameter :: ONE_SIXTH = 1._wp/6._wp
+  real(wp), parameter :: PI        = 3.141592654_wp
 
 contains
 
@@ -124,11 +126,11 @@ contains
 
     implicit none
 
-    real, intent(in) :: Re_crit
-    real, intent(in) :: df_min
-    real, intent(in) :: df_max
-    real, intent(in) :: stick_min
-    real, intent(in) :: stick_max
+    real(wp), intent(in) :: Re_crit
+    real(wp), intent(in) :: df_min
+    real(wp), intent(in) :: df_max
+    real(wp), intent(in) :: stick_min
+    real(wp), intent(in) :: stick_max
 
     agg_Re_crit    = Re_crit
     agg_df_min     = df_min
@@ -154,26 +156,26 @@ contains
     implicit none
 
     integer,                 intent(in) :: Ntypes        ! Number of individual primary particle types
-    real, dimension(Ntypes), intent(in) :: dp_pp         ! Primary particle diameters (m)
-    real, dimension(Ntypes), intent(in) :: rho_pp        ! Primary particle densities (kg/m3)
-    real, dimension(Ntypes), intent(in) :: n_pp          ! Number of individual primary particles per unit volume (#/m3)
-    real, dimension(Ntypes), intent(in) :: A_pp          ! Total surface area of individual primary particles per unit volume (m2/m3)
-    real, dimension(Ntypes), intent(in) :: V_pp          ! Total volume of individual primary particles per unit volume (m3/m3)
-    real, dimension(Ntypes), intent(in) :: stickiness_pp ! Stickiness of individual primary particles - value range: 0-1 (-)
-    real,                    intent(in) :: mu            ! molecular dynamic viscosity of sea water (kg/(m*s))
+    real(wp), dimension(Ntypes), intent(in) :: dp_pp         ! Primary particle diameters (m)
+    real(wp), dimension(Ntypes), intent(in) :: rho_pp        ! Primary particle densities (kg/m3)
+    real(wp), dimension(Ntypes), intent(in) :: n_pp          ! Number of individual primary particles per unit volume (#/m3)
+    real(wp), dimension(Ntypes), intent(in) :: A_pp          ! Total surface area of individual primary particles per unit volume (m2/m3)
+    real(wp), dimension(Ntypes), intent(in) :: V_pp          ! Total volume of individual primary particles per unit volume (m3/m3)
+    real(wp), dimension(Ntypes), intent(in) :: stickiness_pp ! Stickiness of individual primary particles - value range: 0-1 (-)
+    real(wp),                    intent(in) :: mu            ! molecular dynamic viscosity of sea water (kg/(m*s))
 
     integer :: ipp
-    real    :: stickiness_mapped
-    real    :: A_total
-    real    :: V_solid
-    real    :: Vdpfrac
+    real(wp)    :: stickiness_mapped
+    real(wp)    :: A_total
+    real(wp)    :: V_solid
+    real(wp)    :: Vdpfrac
 
-    av_dp          = 0.
-    av_rho_p       = 0.
-    stickiness_agg = 0.
-    A_total        = 0.
-    V_solid        = 0.
-    Vdpfrac        = 0.
+    av_dp          = 0._wp
+    av_rho_p       = 0._wp
+    stickiness_agg = 0._wp
+    A_total        = 0._wp
+    V_solid        = 0._wp
+    Vdpfrac        = 0._wp
 
     ! ------ calc mean aggregate stickiness
     do ipp = 1,Ntypes
@@ -212,20 +214,20 @@ contains
     ! slope = -0.5*(3+df+(2+df-D2)/(2-b)) reduces to:
     !
     ! careful: for df=1.5904: b_agg=2*df where w_s is undefined.
-    b_agg = 0.5*(3. + df_agg + (2. + df_agg - min(2., df_agg))/(2. - BJ2))
+    b_agg = 0.5_wp*(3._wp + df_agg + (2._wp + df_agg - min(2._wp, df_agg))/(2._wp - BJ2))
 
 
     ! ----- calc primary particle mean diameter and mean density
     ! primary particle mean diameter according to Bushell & Amal 1998, 2000
     ! sum(n_i) not changing - can be pulled out and thus cancels out
     do ipp = 1,Ntypes
-      av_dp   = av_dp   + n_pp(ipp)*dp_pp(ipp)**3.
+      av_dp   = av_dp   + n_pp(ipp)*dp_pp(ipp)**3
       Vdpfrac = Vdpfrac + n_pp(ipp)*dp_pp(ipp)**df_agg
 
       av_rho_p = av_rho_p + V_pp(ipp)*rho_pp(ipp)
       V_solid  = V_solid  + V_pp(ipp)
     enddo
-    av_dp    = (av_dp/Vdpfrac)**(1./(3. - df_agg))
+    av_dp    = (av_dp/Vdpfrac)**(1._wp/(3._wp - df_agg))
     av_rho_p = av_rho_p/V_solid
     !    av_dp    = (av_dp/(Vdpfrac+EPS_ONE))**(1./(3. - df_agg))
     !    av_rho_p = av_rho_p/(V_solid+EPS_ONE)
@@ -247,7 +249,7 @@ contains
 
     implicit none
 
-    real, intent(in) :: mu
+    real(wp), intent(in) :: mu
 
     ws_aggregates = ws_Re(Lmax_agg,mu)
 
@@ -262,19 +264,19 @@ contains
 
     implicit none
     ! Arguments
-    real, intent(in) :: AJ
-    real, intent(in) :: BJ
-    real, intent(in) :: Re
-    real, intent(in) :: mu
+    real(wp), intent(in) :: AJ
+    real(wp), intent(in) :: BJ
+    real(wp), intent(in) :: Re
+    real(wp), intent(in) :: mu
 
     ! Local variables
 
-    real :: nu_vis
+    real(wp) :: nu_vis
 
     nu_vis =  mu/rho_aq
 
-    get_dRe = (Re*nu_vis)**((2. - BJ)/df_agg)/(4./3.*(av_rho_p - rho_aq)/rho_aq                    &
-           *av_dp**(3. - df_agg)*grav_acc_const/(AJ*nu_vis**(BJ)))**(1./df_agg)
+    get_dRe = (Re*nu_vis)**((2. - BJ)/df_agg)/(4._wp/3._wp*(av_rho_p - rho_aq)/rho_aq              &
+           *av_dp**(3. - df_agg)*grav_acc_const/(AJ*nu_vis**(BJ)))**(1._wp/df_agg)
 
   end function get_dRe
 
@@ -286,25 +288,25 @@ contains
     !!
     implicit none
 
-    real, intent(in) :: AJ
-    real, intent(in) :: BJ
-    real, intent(in) :: upper_bound
-    real, intent(in) :: lower_bound
-    real, intent(in) :: mu
+    real(wp), intent(in) :: AJ
+    real(wp), intent(in) :: BJ
+    real(wp), intent(in) :: upper_bound
+    real(wp), intent(in) :: lower_bound
+    real(wp), intent(in) :: mu
 
     ! Local variables
-    real :: nu_vis
+    real(wp) :: nu_vis
 
     nu_vis =  mu/rho_aq
-    get_ws_agg_integral = (4./3.*(av_rho_p - rho_aq)/rho_aq                                        &
-                        & *av_dp**(3. - df_agg)*grav_acc_const                                     &
-                        & /(AJ*nu_vis**BJ))**(1./(2. - BJ))                                        &
-                        & *(upper_bound**(1. - b_agg + df_agg                                      &
-                        & + (BJ + df_agg - 2.)/(2. - BJ))                                          &
-                        & /(1. - b_agg + df_agg + (BJ + df_agg - 2.)/(2. - BJ))                    &
-                        & - lower_bound**(1. - b_agg + df_agg + (BJ + df_agg -2.)                  &
-                        & /(2. - BJ))                                                              &
-                        & /(1. - b_agg + df_agg + (BJ + df_agg - 2.)/(2. - BJ)))
+    get_ws_agg_integral = (4._wp/3._wp*(av_rho_p - rho_aq)/rho_aq                                  &
+                        & *av_dp**(3._wp - df_agg)*grav_acc_const                                  &
+                        & /(AJ*nu_vis**BJ))**(1._wp/(2._wp - BJ))                                  &
+                        & *(upper_bound**(1._wp - b_agg + df_agg                                   &
+                        & + (BJ + df_agg - 2._wp)/(2._wp - BJ))                                    &
+                        & /(1._wp - b_agg + df_agg + (BJ + df_agg - 2._wp)/(2._wp - BJ))           &
+                        & - lower_bound**(1._wp - b_agg + df_agg + (BJ + df_agg -2._wp)            &
+                        & /(2._wp - BJ))                                                           &
+                        & /(1._wp - b_agg + df_agg + (BJ + df_agg - 2._wp)/(2._wp - BJ)))
 
   end function get_ws_agg_integral
 
@@ -323,8 +325,8 @@ contains
 
     implicit none
 
-    real, intent(in) :: dmax_agg
-    real, intent(in) :: mu
+    real(wp), intent(in) :: dmax_agg
+    real(wp), intent(in) :: mu
 
     ! Local
     real :: d_Re01, d_Re10, d_low, ws_agg_ints
@@ -333,12 +335,12 @@ contains
     ! for shear-driven break-up, check against integration bounds
     ! calc integration limits for Re-dependent sinking:
     ! Re=0.1
-    d_Re01 = get_dRe(AJ1, BJ1, 0.1,mu)
+    d_Re01 = get_dRe(AJ1, BJ1, 0.1_wp,mu)
     ! Re=10
-    d_Re10 = get_dRe(AJ2, BJ2, 10.,mu)
+    d_Re10 = get_dRe(AJ2, BJ2, 10._wp,mu)
     d_low = av_dp
 
-    ws_agg_ints = 0.
+    ws_agg_ints = 0._wp
     if(dmax_agg >= d_Re01)then ! Re > 0.1
                                        ! - collect full range up to
                                        ! 0.1, (dp->d_Re1) and set lower bound to
@@ -365,9 +367,9 @@ contains
 
     ! concentration-weighted mean sinking velocity
     ws_Re = (ws_agg_ints                                                                           &
-            & /((dmax_agg**(1. + df_agg - b_agg)                                                   &
-            & - av_dp**(1. + df_agg - b_agg))                                                      &
-            & / (1. + df_agg - b_agg)))  ! (m/s)
+            & /((dmax_agg**(1._wp + df_agg - b_agg)                                                &
+            & - av_dp**(1._wp + df_agg - b_agg))                                                   &
+            & / (1._wp + df_agg - b_agg)))  ! (m/s)
 
   end function ws_Re
 
@@ -396,13 +398,13 @@ contains
 
     implicit none
 
-    real,intent(in) :: mu
-    real        :: nu_vis
+    real(wp),intent(in) :: mu
+    real(wp)        :: nu_vis
 
     nu_vis  =  mu/rho_aq
-    max_agg_diam_white = (agg_Re_crit*nu_vis)**((2. - BJ3)/df_agg)                                 &
-                        & /((4./3.)*(av_rho_p - rho_aq)/rho_aq                                     &
-                        & *av_dp**(3. - df_agg)*grav_acc_const                                     &
+    max_agg_diam_white = (agg_Re_crit*nu_vis)**((2._wp - BJ3)/df_agg)                              &
+                        & /((4._wp/3._wp)*(av_rho_p - rho_aq)/rho_aq                               &
+                        & *av_dp**(3._wp - df_agg)*grav_acc_const                                  &
                         & /(AJ3*nu_vis**BJ3))**(1./df_agg)
 
   end function max_agg_diam_white
@@ -412,31 +414,34 @@ contains
   !=================================================================================================
   ! DIAGNOSTICS
 
-  real function volweighted_agg_density()
+  real(wp) function volweighted_agg_density()
 
     ! Volume-weighted mean aggregate density
-    volweighted_agg_density = (av_rho_p-rho_aq)*av_dp**(3.-df_agg)                                 &
-                            & *(4.-b_agg)*(Lmax_agg**(1.+df_agg-b_agg) - av_dp**(1.+df_agg-b_agg)) &
-                            &  / ((1.+df_agg-b_agg)                                                &
-                            & *(Lmax_agg**(4.-b_agg) - av_dp**(4.-b_agg))) + rho_aq
+    volweighted_agg_density = (av_rho_p-rho_aq)*av_dp**(3._wp-df_agg)                              &
+                            & *(4._wp-b_agg)*(Lmax_agg**(1._wp+df_agg-b_agg)                       &
+                            &                        - av_dp**(1._wp+df_agg-b_agg))                &
+                            &  / ((1._wp+df_agg-b_agg)                                             &
+                            & *(Lmax_agg**(4._wp-b_agg) - av_dp**(4._wp-b_agg))) + rho_aq
 
   end function volweighted_agg_density
 
   !=================================================================================================
-  real function volweighted_agg_porosity()
+  real(wp) function volweighted_agg_porosity()
 
     ! Volume-weighted mean aggregate porosity
-    volweighted_agg_porosity =  1. - ((4.-b_agg)*av_dp**(3.-df_agg)                                &
-                             &         *(Lmax_agg**(1.+df_agg-b_agg) - av_dp**(1.+df_agg-b_agg)))  &
-                             &       /((1.+df_agg-b_agg)*(Lmax_agg**(4.-b_agg) - av_dp**(4.-b_agg)))
+    volweighted_agg_porosity =  1._wp - ((4._wp-b_agg)*av_dp**(3._wp-df_agg)                       &
+                             &         *(Lmax_agg**(1._wp+df_agg-b_agg)                            &
+                             &                     - av_dp**(1._wp+df_agg-b_agg)))                 &
+                             &       /((1._wp+df_agg-b_agg)*(Lmax_agg**(4._wp-b_agg)               &
+                             &                                  - av_dp**(4._wp-b_agg)))
 
   end function volweighted_agg_porosity
 
   !=================================================================================================
-  real function conc_weighted_mean_agg_diameter()
-    conc_weighted_mean_agg_diameter =  (1. + df_agg - b_agg) / (2. + df_agg - b_agg)               &
-                          & *(Lmax_agg**(2. + df_agg - b_agg) - av_dp**(2. + df_agg - b_agg))      &
-                          & / (Lmax_agg**(1.+df_agg-b_agg) - av_dp**(1. + df_agg-b_agg))
+  real(wp) function conc_weighted_mean_agg_diameter()
+    conc_weighted_mean_agg_diameter =  (1._wp + df_agg - b_agg) / (2._wp + df_agg - b_agg)         &
+                          & *(Lmax_agg**(2._wp + df_agg - b_agg) - av_dp**(2._wp + df_agg - b_agg))&
+                          & / (Lmax_agg**(1._wp+df_agg-b_agg) - av_dp**(1._wp + df_agg-b_agg))
 
   end function conc_weighted_mean_agg_diameter
 
@@ -450,7 +455,7 @@ contains
   !=================================================================================================
   ! CURRENTLY UN-USED FUNCTIONS
 
-  real  function mass_factor(dp,df,rhop)
+  real(wp)  function mass_factor(dp,df,rhop)
     !-----------------------------------------------------------------------
     !>
     !! mass_factor calculates the mass factor for the mass of a single
@@ -458,18 +463,18 @@ contains
     !!
     implicit none
 
-    real, intent(in) :: dp
-    real, intent(in) :: df
-    real, intent(in) :: rhop
+    real(wp), intent(in) :: dp
+    real(wp), intent(in) :: df
+    real(wp), intent(in) :: rhop
 
     ! mass factor
-    mass_factor = ONE_SIXTH * PI * dp**(3. - df) * rhop
+    mass_factor = ONE_SIXTH * PI * dp**(3._wp - df) * rhop
 
   end function mass_factor
 
 
   !=================================================================================================
-  real function rho_agg(d,rhop,dp,df,rho)
+  real(wp) function rho_agg(d,rhop,dp,df,rho)
     !-----------------------------------------------------------------------
     !>
     !! rho_agg provides the aggregate density
@@ -477,18 +482,18 @@ contains
 
     implicit none
 
-    real, intent(in) :: d
-    real, intent(in) :: rhop
-    real, intent(in) :: dp
-    real, intent(in) :: df
-    real, intent(in) :: rho
+    real(wp), intent(in) :: d
+    real(wp), intent(in) :: rhop
+    real(wp), intent(in) :: dp
+    real(wp), intent(in) :: df
+    real(wp), intent(in) :: rho
 
-    rho_agg =  (rhop - rho)*(dp/d)**(3. - df) + rho
+    rho_agg =  (rhop - rho)*(dp/d)**(3._wp - df) + rho
 
   end function rho_agg
 
   !=================================================================================================
-  real function Re_fun(ws,d,mu,rho)
+  real(wp) function Re_fun(ws,d,mu,rho)
     !-----------------------------------------------------------------------
     !>
     !! Particle Reynolds number for settling particles (based on diameter)
@@ -496,7 +501,7 @@ contains
 
     implicit none
 
-    real,intent(in) :: ws,d,mu,rho
+    real(wp),intent(in) :: ws,d,mu,rho
 
     Re_fun = abs(ws*d*rho/mu)
 

--- a/src/mo_m4ago_core.f90
+++ b/src/mo_m4ago_core.f90
@@ -95,6 +95,7 @@ module mo_m4ago_core
   real, protected :: stickiness_min,stickiness_max     ! minimum and maximum stickiness of marine aggregates
   real, protected :: stickiness_agg                    ! mean aggregate stickiness
   real, protected :: ws_aggregates                     ! mean mass concentration-weighted sinking velocity of aggregates
+  !$OMP THREADPRIVATE(av_dp,av_rho_p,df_agg,b_agg,Lmax_agg,stickiness_agg,ws_aggregates)
 
 
   real, parameter :: rho_aq         = 1025.            ! water reference density  (1025 kg/m^3)

--- a/src/mo_m4ago_core.f90
+++ b/src/mo_m4ago_core.f90
@@ -97,7 +97,6 @@ module mo_m4ago_core
   real(wp), protected :: stickiness_min,stickiness_max     ! minimum and maximum stickiness of marine aggregates
   real(wp), protected :: stickiness_agg                    ! mean aggregate stickiness
   real(wp), protected :: ws_aggregates                     ! mean mass concentration-weighted sinking velocity of aggregates
-  !$OMP THREADPRIVATE(av_dp,av_rho_p,df_agg,b_agg,Lmax_agg,stickiness_agg,ws_aggregates)
 
   real(wp), parameter :: rho_aq         = 1025._wp            ! water reference density  (1025 kg/m^3)
   real(wp), parameter :: grav_acc_const = 9.81_wp             ! gravitational acceleration constant

--- a/src/mo_m4ago_kind.F90
+++ b/src/mo_m4ago_kind.F90
@@ -12,13 +12,12 @@ use iso_fortran_env, only:  int32, int64, real32, real64, real128
 
   public :: wp
 
-
-#ifdef REAL64
-  integer,parameter :: rk = real64
+#ifdef REAL32
+  integer,parameter :: rk = real32
 #elif REAL128
   integer,parameter :: rk = real128
 #else
-  integer,parameter :: rk = real32
+  integer,parameter :: rk = real64
 #endif
 
 !#ifdef INT64
@@ -28,12 +27,10 @@ use iso_fortran_env, only:  int32, int64, real32, real64, real128
 !#endif
 
 
-
-
 #ifdef HAMOCC
   integer, parameter :: wp = r8 !selected_real_kind()
 #else
-  integer, parameter :: wp = real64
+  integer, parameter :: wp = rk
 #endif
 
 end module mo_m4ago_kind

--- a/src/mo_m4ago_kind.F90
+++ b/src/mo_m4ago_kind.F90
@@ -1,0 +1,39 @@
+module mo_m4ago_kind
+
+use iso_fortran_env, only:  int32, int64, real32, real64, real128
+
+#ifdef HAMOCC
+  use mod_types, only: r8
+#endif
+
+  implicit none
+
+  private
+
+  public :: wp
+
+
+#ifdef REAL64
+  integer,parameter :: rk = real64
+#elif REAL128
+  integer,parameter :: rk = real128
+#else
+  integer,parameter :: rk = real32
+#endif
+
+!#ifdef INT64
+!  integer, parameter :: ik = int64
+!#else
+!  integer, parameter :: ik = int32
+!#endif
+
+
+
+
+#ifdef HAMOCC
+  integer, parameter :: wp = r8 !selected_real_kind()
+#else
+  integer, parameter :: wp = real64
+#endif
+
+end module mo_m4ago_kind

--- a/src/mo_m4ago_physics.f90
+++ b/src/mo_m4ago_physics.f90
@@ -67,6 +67,8 @@
 
 module mo_m4ago_physics
 
+  use mo_m4ago_kind, only: wp
+
   implicit none
 
   private
@@ -90,16 +92,16 @@ contains
     real, intent(in) :: ptho_val  ! temperature [deg C]
     real, intent(in) :: psao_val  ! salinity [psu]
 
-    mol_dyn_vis = 0.1 & ! Unit conversion: g / (cm*s) -> kg / (m*s)
-                      &     *(1.79e-2                                                         &
-                      &     - 6.1299e-4*ptho_val + 1.4467e-5*ptho_val**2.                     &
-                      &     - 1.6826e-7*ptho_val**3.                                          &
-                      &     - 1.8266e-7*press_val  + 9.8972e-12*press_val**2.                 &
-                      &     + 2.4727e-5*psao_val                                              &
-                      &     + psao_val*(4.8429e-7*ptho_val - 4.7172e-8*ptho_val**2.           &
-                      &     + 7.5986e-10*ptho_val**3.)                                        &
-                      &     + press_val*(1.3817e-8*ptho_val - 2.6363e-10*ptho_val**2.)        &
-                      &     - press_val**2.*(6.3255e-13*ptho_val - 1.2116e-14*ptho_val**2.))
+    mol_dyn_vis = 0.1_wp & ! Unit conversion: g / (cm*s) -> kg / (m*s)
+                      &     *(1.79e-2_wp                                                           &
+                      &     - 6.1299e-4_wp*ptho_val + 1.4467e-5_wp*ptho_val**2                     &
+                      &     - 1.6826e-7_wp*ptho_val**3                                             &
+                      &     - 1.8266e-7_wp*press_val  + 9.8972e-12_wp*press_val**2                 &
+                      &     + 2.4727e-5_wp*psao_val                                                &
+                      &     + psao_val*(4.8429e-7_wp*ptho_val - 4.7172e-8_wp*ptho_val**2           &
+                      &     + 7.5986e-10_wp*ptho_val**3)                                           &
+                      &     + press_val*(1.3817e-8_wp*ptho_val - 2.6363e-10_wp*ptho_val**2)        &
+                      &     - press_val**2 * (6.3255e-13_wp*ptho_val - 1.2116e-14_wp*ptho_val**2))
 
 
 

--- a/src/mo_m4ago_physics.f90
+++ b/src/mo_m4ago_physics.f90
@@ -88,9 +88,9 @@ contains
     !!
     !! returns: molecular dynamic viscosity [kg/(m*s)]
 
-    real, intent(in) :: press_val ! pressure [dbar]
-    real, intent(in) :: ptho_val  ! temperature [deg C]
-    real, intent(in) :: psao_val  ! salinity [psu]
+    real(wp), intent(in) :: press_val ! pressure [dbar]
+    real(wp), intent(in) :: ptho_val  ! temperature [deg C]
+    real(wp), intent(in) :: psao_val  ! salinity [psu]
 
     mol_dyn_vis = 0.1_wp & ! Unit conversion: g / (cm*s) -> kg / (m*s)
                       &     *(1.79e-2_wp                                                           &


### PR DESCRIPTION
This PR introduces the `mo_m4ago_kind.F90` to explicitly set the working precision of real numbers. Tested on betzy in combination with NorESM2.1.3 and BLOM tag v1.6.2. bfb with current version.  